### PR TITLE
Changes since your save link on new version game transfer

### DIFF
--- a/chroot/bin/crawl-git-launcher.sh
+++ b/chroot/bin/crawl-git-launcher.sh
@@ -238,8 +238,9 @@ if [[ -n "$SAVE" ]]; then
 		cecho "There's a newer version ($new_ver) that can load your save."
                 cecho -n "[T]ransfer your save to this version?"
                 wcat <<EOF
-<p>There's a newer version (<a href='$compare_url' target='_blank'>$new_ver</a>) that can load your save.</p>
+<p>There's a newer version ($new_ver) that can load your save.</p>
 <p>[T]ransfer your save to this version?</p>
+<a href='$compare_url' target='_blank'>Changes since your save</a>
 <input type='button' class='button' data-key='N' value='No' style='float:right;'>
 <input type='button' class='button' data-key='T' value='Yes' style='float:right;'>
 "}
@@ -249,7 +250,8 @@ EOF
 	    else
                 cecho -n "[T]ransfer your save to the latest version ($new_ver)?"
                 wcat <<EOF
-<p>[T]ransfer your save to the latest version (<a href='$compare_url' target='_blank'>$new_ver</a>)?</p>
+<p>[T]ransfer your save to the latest version ($new_ver)?</p>
+<a href='$compare_url' target='_blank'>Changes since your save</a>
 <input type='button' class='button' data-key='N' value='No' style='float:right;'>
 <input type='button' class='button' data-key='T' value='Yes' style='float:right;'>
 "}

--- a/chroot/bin/crawl-git-launcher.sh
+++ b/chroot/bin/crawl-git-launcher.sh
@@ -133,9 +133,10 @@ LIMIT 1;
 EOF
 }
 
-github-commit-url() {
-    local hash=$1
-    echo $CRAWL_GIT_HTTPS_URL/commit/$hash
+github-compare-url() {
+    local our_hash=$1
+    local new_hash=$2
+    echo $CRAWL_GIT_HTTPS_URL/compare/$our_hash...$new_hash
 }
 
 user-is-admin() {
@@ -226,7 +227,7 @@ if [[ -n "$SAVE" ]]; then
 	OUR_SGV_MAJOR="$(major-version-for-game $OUR_GAME_HASH)"
 	NEW_GAME_HASH="$(newest-version-with-major-version $OUR_SGV_MAJOR)"
         new_ver="$(hash-description $NEW_GAME_HASH)"
-	commit_url="$(github-commit-url $NEW_GAME_HASH)"
+	compare_url="$(github-compare-url $OUR_GAME_HASH $NEW_GAME_HASH)"
 
         if [[ "$OUR_GAME_HASH" != "$NEW_GAME_HASH" &&
                     "$TRANSFER_ENABLED" == "1" ]]; then
@@ -237,7 +238,7 @@ if [[ -n "$SAVE" ]]; then
 		cecho "There's a newer version ($new_ver) that can load your save."
                 cecho -n "[T]ransfer your save to this version?"
                 wcat <<EOF
-<p>There's a newer version (<a href='$commit_url' target='_blank'>$new_ver</a>) that can load your save.</p>
+<p>There's a newer version (<a href='$compare_url' target='_blank'>$new_ver</a>) that can load your save.</p>
 <p>[T]ransfer your save to this version?</p>
 <input type='button' class='button' data-key='N' value='No' style='float:right;'>
 <input type='button' class='button' data-key='T' value='Yes' style='float:right;'>
@@ -248,7 +249,7 @@ EOF
 	    else
                 cecho -n "[T]ransfer your save to the latest version ($new_ver)?"
                 wcat <<EOF
-<p>[T]ransfer your save to the latest version (<a href='$commit_url' target='_blank'>$new_ver</a>)?</p>
+<p>[T]ransfer your save to the latest version (<a href='$compare_url' target='_blank'>$new_ver</a>)?</p>
 <input type='button' class='button' data-key='N' value='No' style='float:right;'>
 <input type='button' class='button' data-key='T' value='Yes' style='float:right;'>
 "}

--- a/chroot/bin/crawl-git-launcher.sh
+++ b/chroot/bin/crawl-git-launcher.sh
@@ -28,6 +28,7 @@ export LC_ALL=en_US.UTF-8
 set -o nounset
 
 CRAWL_GIT_DIR="%%CHROOT_CRAWL_BASEDIR%%"
+CRAWL_GIT_HTTPS_URL="%%CHROOT_CRAWL_GIT_HTTPS_URL%%"
 USER_DB="%%CHROOT_LOGIN_DB%%"
 CRAWL_BINARY_PATH="%%CHROOT_CRAWL_BINARY_PATH%%"
 BINARY_BASE_NAME="%%GAME%%"
@@ -132,6 +133,11 @@ LIMIT 1;
 EOF
 }
 
+github-commit-url() {
+    local hash=$1
+    echo $CRAWL_GIT_HTTPS_URL/commit/$hash
+}
+
 user-is-admin() {
     local found="$(echo "SELECT username FROM dglusers
                          WHERE username='$CHAR_NAME' AND (flags & 1) = 1;" |
@@ -220,6 +226,7 @@ if [[ -n "$SAVE" ]]; then
 	OUR_SGV_MAJOR="$(major-version-for-game $OUR_GAME_HASH)"
 	NEW_GAME_HASH="$(newest-version-with-major-version $OUR_SGV_MAJOR)"
         new_ver="$(hash-description $NEW_GAME_HASH)"
+	commit_url="$(github-commit-url $NEW_GAME_HASH)"
 
         if [[ "$OUR_GAME_HASH" != "$NEW_GAME_HASH" &&
                     "$TRANSFER_ENABLED" == "1" ]]; then
@@ -230,7 +237,7 @@ if [[ -n "$SAVE" ]]; then
 		cecho "There's a newer version ($new_ver) that can load your save."
                 cecho -n "[T]ransfer your save to this version?"
                 wcat <<EOF
-<p>There's a newer version ($new_ver) that can load your save.</p>
+<p>There's a newer version (<a href='$commit_url' target='_blank'>$new_ver</a>) that can load your save.</p>
 <p>[T]ransfer your save to this version?</p>
 <input type='button' class='button' data-key='N' value='No' style='float:right;'>
 <input type='button' class='button' data-key='T' value='Yes' style='float:right;'>
@@ -241,7 +248,7 @@ EOF
 	    else
                 cecho -n "[T]ransfer your save to the latest version ($new_ver)?"
                 wcat <<EOF
-<p>[T]ransfer your save to the latest version ($new_ver)?</p>
+<p>[T]ransfer your save to the latest version (<a href='$commit_url' target='_blank'>$new_ver</a>)?</p>
 <input type='button' class='button' data-key='N' value='No' style='float:right;'>
 <input type='button' class='button' data-key='T' value='Yes' style='float:right;'>
 "}

--- a/crawl-git.conf
+++ b/crawl-git.conf
@@ -9,6 +9,9 @@ CRAWL_BUILD_DIR=$DGL_CONF_HOME/crawl-build
 CRAWL_REPOSITORY_DIR=crawl-git-repository
 CRAWL_REPO=$DGL_CONF_HOME/crawl-build/$CRAWL_REPOSITORY_DIR
 CRAWL_GIT_URL=git://github.com/crawl/crawl.git
+CRAWL_GIT_HTTPS_URL=https://github.com/crawl/crawl
+
+export CHROOT_CRAWL_GIT_HTTPS_URL=$CRAWL_GIT_HTTPS_URL
 
 export CHROOT_CRAWL_BINARY_PATH="/usr/games"
 export CRAWL_BINARY_PATH="$DGL_CHROOT$CHROOT_CRAWL_BINARY_PATH"


### PR DESCRIPTION
This will create a link on the new version game transfer dialogue on webtiles when there is a newer crawl-git version than your currently saved game, comparing the hash of your game with the hash of the new version, using github's compare page. This is a neat little convenience feature for those curious about what exactly is changing from build to build and how it may impact their current game.

Tested with the provided docker build, inserting a bogus value into the versions table to indicate a new version had been created, resulting in the following screenshot. Currently looks like this: https://i.imgur.com/wzTf04g.png

The concept seems fine, could be room to improve in design/implementation. That is, how it's configured, where the link appears, the text of the link, etc. Could be edge cases I'm not thinking of.