### PR TITLE
Force checkout and reset any possible changes to prevent edge cases

### DIFF
--- a/crawl-build/update-public-repository.sh
+++ b/crawl-build/update-public-repository.sh
@@ -20,10 +20,11 @@ update-crawl-ref() {
     say "Updating git repository $REPO_DIR"
     ( cd $REPO_DIR && git checkout -f &&
         git checkout $BRANCH &&
+        git reset --hard &&
         git pull )
     if [[ -n "$REVISION" ]]; then
         say "Checking out requested revision: $REVISION"
-        ( cd $REPO_DIR && git checkout "$REVISION" )
+        ( cd $REPO_DIR && git checkout -f "$REVISION" && git reset --hard )
     fi
 }
 


### PR DESCRIPTION
Force checkout and reset any possible changes which are leftover after checking out to prevent edge cases - both where either checkouts are blocked due to unexpected changes(failing to change branch and thus not starting the build) and when checkout leaves an untracked change in due to no conflicts(causing weird build failures).