### PR TITLE
Exit 0 on building an already installed version (stable or trunk), instead of erroring out

### DIFF
--- a/crawl-build/update-crawl-stable-build.sh
+++ b/crawl-build/update-crawl-stable-build.sh
@@ -38,7 +38,7 @@ VER_STR_OLD="$(($CRAWL_BINARY_PATH/$GAME -version 2>/dev/null || true) | sed -ne
 REVISION_OLD="${VER_STR_OLD##*-g}"
 
 [[ "$REVISION" == "$REVISION_OLD" || "$VER_STR" = "$VER_STR_OLD" ]] && \
-    abort-saying "Nothing new to install at the moment: you asked for $REVISION_FULL and it's already installed"
+    exit-saying "Nothing new to install at the moment: you asked for $REVISION_FULL and it's already installed"
 
 prompt "start update build"
 

--- a/crawl-build/update-crawl-trunk-build.sh
+++ b/crawl-build/update-crawl-trunk-build.sh
@@ -22,7 +22,7 @@ REVISION_FULL="$(git-do describe --long HEAD)"
 REVISION_OLD="$(echo "select hash from versions order by time desc limit 1;" | sqlite3 ${VERSIONS_DB})"
 
 [[ "$REVISION" == "$REVISION_OLD" ]] && \
-    abort-saying "Nothing new to install at the moment: you asked for $REVISION_FULL and it's already installed"
+    exit-saying "Nothing new to install at the moment: you asked for $REVISION_FULL and it's already installed"
 
 prompt "start update build"
 
@@ -69,7 +69,7 @@ if [[ "$(uname)" != "Darwin" ]] && {
         grep ^"$DGL_USER";
     }
 then
-    abort-saying "There are already active instances of this version (${REVISION_FULL}) running"
+    exit-saying "There are already active instances of this version (${REVISION_FULL}) running"
 fi
 
 echo "Searching for version tags..."

--- a/sh-utils
+++ b/sh-utils
@@ -65,6 +65,11 @@ abort-saying() {
     exit 1
 }
 
+exit-saying() {
+    echo -e "$@, exiting."
+    exit 0
+}
+
 # Call with any argument to disable prompts
 enable-prompts() {
     local opt


### PR DESCRIPTION
I believe most server admins run crawl builds on a schedule, and most of the time (for stable at least), there is no change. In its current form, script stops with an exit 1, so scheduled jobs regullary returns an error. I personaly set up alert rules for systemd failed units, and get notified on an almost daily basis.
I don't think this should be considered an error, so I propose to exit 0 for this usecase instead.
It is done by usgin a new similar exit function in place of the existing one, which is still used elsewhere. Feel free to adjust these changes the way you want.